### PR TITLE
Add short names to CRD definitions

### DIFF
--- a/apis/access/v1alpha1/traffictarget_types.go
+++ b/apis/access/v1alpha1/traffictarget_types.go
@@ -59,6 +59,7 @@ type IdentityBindingSubject struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=tt
 
 // TrafficTarget is the Schema for the traffictargets API
 // TrafficTarget associates a set of traffic definitions (rules) with a service identity which is allocated to a group of pods.

--- a/apis/access/v1alpha2/traffictarget_types.go
+++ b/apis/access/v1alpha2/traffictarget_types.go
@@ -75,6 +75,7 @@ type TrafficTargetStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=tt
 
 // TrafficTarget associates a set of traffic definitions (rules) with a service identity which is allocated to a group of pods.
 // Access is controlled via referenced TrafficSpecs and by a list of source service identities.

--- a/apis/access/v1alpha3/traffictarget_types.go
+++ b/apis/access/v1alpha3/traffictarget_types.go
@@ -71,6 +71,7 @@ type TrafficTargetStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
+//+kubebuilder:resource:shortName=tt
 
 // TrafficTarget associates a set of traffic definitions (rules) with a service identity which is allocated to a group of pods.
 // Access is controlled via referenced TrafficSpecs and by a list of source service identities.

--- a/apis/specs/v1alpha1/httproutegroup_types.go
+++ b/apis/specs/v1alpha1/httproutegroup_types.go
@@ -72,6 +72,7 @@ type HTTPRouteGroupStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=htr
 
 // HTTPRouteGroup is the Schema for the httproutegroups API
 type HTTPRouteGroup struct {

--- a/apis/specs/v1alpha1/tcproute_types.go
+++ b/apis/specs/v1alpha1/tcproute_types.go
@@ -31,6 +31,7 @@ type TCPRouteStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=tr
 
 // TCPRoute is the Schema for the tcproutes API
 type TCPRoute struct {

--- a/apis/specs/v1alpha2/httproutegroup_types.go
+++ b/apis/specs/v1alpha2/httproutegroup_types.go
@@ -76,6 +76,7 @@ type HTTPRouteGroupStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=htr
 
 // HTTPRouteGroup is the Schema for the httproutegroups API
 // It is used to describe HTTP/1 and HTTP/2 traffic.

--- a/apis/specs/v1alpha2/tcproute_types.go
+++ b/apis/specs/v1alpha2/tcproute_types.go
@@ -31,6 +31,7 @@ type TCPRouteStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=tr
 
 // TCPRoute is the Schema for the tcproutes API
 type TCPRoute struct {

--- a/apis/specs/v1alpha3/httproutegroup_types.go
+++ b/apis/specs/v1alpha3/httproutegroup_types.go
@@ -86,6 +86,7 @@ type HTTPRouteGroupStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=htr
 
 // HTTPRouteGroup is the Schema for the httproutegroups API
 // It is used to describe HTTP/1 and HTTP/2 traffic.

--- a/apis/specs/v1alpha3/tcproute_types.go
+++ b/apis/specs/v1alpha3/tcproute_types.go
@@ -38,6 +38,7 @@ type TCPRouteStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=tr
 
 // TCPRoute is the Schema for the tcproutes API
 type TCPRoute struct {

--- a/apis/specs/v1alpha4/httproutegroup_types.go
+++ b/apis/specs/v1alpha4/httproutegroup_types.go
@@ -86,6 +86,7 @@ type HTTPRouteGroupStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
+//+kubebuilder:resource:shortName=htr
 
 // HTTPRouteGroup is the Schema for the httproutegroups API
 type HTTPRouteGroup struct {

--- a/apis/specs/v1alpha4/tcproute_types.go
+++ b/apis/specs/v1alpha4/tcproute_types.go
@@ -50,6 +50,7 @@ type TCPRouteStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
+//+kubebuilder:resource:shortName=tr
 
 // TCPRoute is the Schema for the tcproutes API
 type TCPRoute struct {

--- a/apis/specs/v1alpha4/udproute_types.go
+++ b/apis/specs/v1alpha4/udproute_types.go
@@ -50,6 +50,7 @@ type UDPRouteStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
+//+kubebuilder:resource:shortName=ur
 
 // UDPRoute is the Schema for the udproutes API
 type UDPRoute struct {

--- a/apis/split/v1alpha1/trafficsplit_types.go
+++ b/apis/split/v1alpha1/trafficsplit_types.go
@@ -47,6 +47,7 @@ type TrafficSplitStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=ts
 
 // TrafficSplit is the Schema for the trafficsplits API
 type TrafficSplit struct {

--- a/apis/split/v1alpha2/trafficsplit_types.go
+++ b/apis/split/v1alpha2/trafficsplit_types.go
@@ -46,6 +46,7 @@ type TrafficSplitStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=ts
 
 // TrafficSplit is the Schema for the trafficsplits API
 type TrafficSplit struct {

--- a/apis/split/v1alpha3/trafficsplit_types.go
+++ b/apis/split/v1alpha3/trafficsplit_types.go
@@ -59,6 +59,7 @@ type TrafficSplitStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=ts
 
 // TrafficSplit is the Schema for the trafficsplits API
 type TrafficSplit struct {

--- a/apis/split/v1alpha4/trafficsplit_types.go
+++ b/apis/split/v1alpha4/trafficsplit_types.go
@@ -60,6 +60,7 @@ type TrafficSplitStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+//+kubebuilder:resource:shortName=ts
 
 // TrafficSplit is the Schema for the trafficsplits API
 type TrafficSplit struct {

--- a/config/crd/bases/access.smi-spec.io_traffictargets.yaml
+++ b/config/crd/bases/access.smi-spec.io_traffictargets.yaml
@@ -13,6 +13,8 @@ spec:
     kind: TrafficTarget
     listKind: TrafficTargetList
     plural: traffictargets
+    shortNames:
+    - tt
     singular: traffictarget
   scope: Namespaced
   versions:

--- a/config/crd/bases/specs.smi-spec.io_httproutegroups.yaml
+++ b/config/crd/bases/specs.smi-spec.io_httproutegroups.yaml
@@ -13,6 +13,8 @@ spec:
     kind: HTTPRouteGroup
     listKind: HTTPRouteGroupList
     plural: httproutegroups
+    shortNames:
+    - htr
     singular: httproutegroup
   scope: Namespaced
   versions:

--- a/config/crd/bases/specs.smi-spec.io_tcproutes.yaml
+++ b/config/crd/bases/specs.smi-spec.io_tcproutes.yaml
@@ -13,6 +13,8 @@ spec:
     kind: TCPRoute
     listKind: TCPRouteList
     plural: tcproutes
+    shortNames:
+    - tr
     singular: tcproute
   scope: Namespaced
   versions:

--- a/config/crd/bases/specs.smi-spec.io_udproutes.yaml
+++ b/config/crd/bases/specs.smi-spec.io_udproutes.yaml
@@ -13,6 +13,8 @@ spec:
     kind: UDPRoute
     listKind: UDPRouteList
     plural: udproutes
+    shortNames:
+    - ur
     singular: udproute
   scope: Namespaced
   versions:

--- a/config/crd/bases/split.smi-spec.io_trafficsplits.yaml
+++ b/config/crd/bases/split.smi-spec.io_trafficsplits.yaml
@@ -13,6 +13,8 @@ spec:
     kind: TrafficSplit
     listKind: TrafficSplitList
     plural: trafficsplits
+    shortNames:
+    - ts
     singular: trafficsplit
   scope: Namespaced
   versions:


### PR DESCRIPTION
This fixes #15 and brings the smi-controller-sdk to parity with smi-sdk-go